### PR TITLE
Upgrade for ES0.90.4

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -45,7 +45,7 @@
     </parent>
 
     <properties>
-        <elasticsearch.version>0.90.3</elasticsearch.version>
+        <elasticsearch.version>0.90.4</elasticsearch.version>
     </properties>
 
     <dependencies>

--- a/src/main/java/org/elasticsearch/action/updatebyquery/IndexUpdateByQueryRequest.java
+++ b/src/main/java/org/elasticsearch/action/updatebyquery/IndexUpdateByQueryRequest.java
@@ -19,29 +19,18 @@
 
 package org.elasticsearch.action.updatebyquery;
 
-import org.elasticsearch.common.collect.Sets;
-import org.elasticsearch.ElasticSearchGenerationException;
+import static org.elasticsearch.action.ValidateActions.addValidationError;
+
+import java.io.IOException;
+import java.util.Arrays;
+import java.util.HashSet;
+import java.util.Set;
+
 import org.elasticsearch.action.ActionRequestValidationException;
-import org.elasticsearch.action.WriteConsistencyLevel;
 import org.elasticsearch.action.support.replication.IndexReplicationOperationRequest;
-import org.elasticsearch.action.support.replication.ReplicationType;
-import org.elasticsearch.client.Requests;
-import org.elasticsearch.common.bytes.BytesArray;
 import org.elasticsearch.common.bytes.BytesReference;
 import org.elasticsearch.common.io.stream.StreamInput;
 import org.elasticsearch.common.io.stream.StreamOutput;
-import org.elasticsearch.common.xcontent.XContentBuilder;
-import org.elasticsearch.common.xcontent.XContentFactory;
-import org.elasticsearch.common.xcontent.XContentParser;
-import org.elasticsearch.common.xcontent.XContentType;
-import org.elasticsearch.search.builder.SearchSourceBuilder;
-
-import java.io.IOException;
-import java.util.Map;
-import java.util.Set;
-
-import static org.elasticsearch.common.collect.Maps.newHashMap;
-import static org.elasticsearch.action.ValidateActions.addValidationError;
 
 /**
  * Represents an update by query request targeted for a specific index.
@@ -51,7 +40,7 @@ public class IndexUpdateByQueryRequest extends IndexReplicationOperationRequest 
     private String[] types = new String[0];
     private BulkResponseOption bulkResponseOption;
     private String[] filteringAliases = new String[0];
-    private Set<String> routing = Sets.newHashSet();
+    private Set<String> routing = new HashSet();
 
     private BytesReference source;
     private boolean sourceUnsafe;
@@ -119,10 +108,12 @@ public class IndexUpdateByQueryRequest extends IndexReplicationOperationRequest 
     @Override
     public void readFrom(StreamInput in) throws IOException {
         super.readFrom(in);
-        types = in.readStringArray();
+        String[] readStringArray = in.readStringArray();
+		types = readStringArray;
         bulkResponseOption = BulkResponseOption.fromId(in.readByte());
-        filteringAliases = in.readStringArray();
-        routing = Sets.newHashSet(in.readStringArray());
+        filteringAliases = readStringArray;
+        routing = new HashSet();
+        routing.addAll(Arrays.asList(readStringArray));
         source = in.readBytesReference();
         sourceUnsafe = false;
     }

--- a/src/main/java/org/elasticsearch/action/updatebyquery/IndexUpdateByQueryResponse.java
+++ b/src/main/java/org/elasticsearch/action/updatebyquery/IndexUpdateByQueryResponse.java
@@ -19,14 +19,14 @@
 
 package org.elasticsearch.action.updatebyquery;
 
-import org.elasticsearch.common.collect.Maps;
+import java.io.IOException;
+import java.util.HashMap;
+import java.util.Map;
+
 import org.elasticsearch.action.ActionResponse;
 import org.elasticsearch.action.bulk.BulkItemResponse;
 import org.elasticsearch.common.io.stream.StreamInput;
 import org.elasticsearch.common.io.stream.StreamOutput;
-
-import java.io.IOException;
-import java.util.Map;
 
 /**
  * Encapsulates the result of an update by query request by bundling all bulk item responses.
@@ -38,8 +38,8 @@ public class IndexUpdateByQueryResponse extends ActionResponse {
     private String index;
     private long totalHits;
     private long updated;
-    private Map<Integer, BulkItemResponse[]> responsesByShard = Maps.newHashMap();
-    private Map<Integer, String> failuresByShard = Maps.newHashMap();
+    private Map<Integer, BulkItemResponse[]> responsesByShard = new HashMap();
+    private Map<Integer, String> failuresByShard = new HashMap();
 
     IndexUpdateByQueryResponse() {
     }

--- a/src/main/java/org/elasticsearch/action/updatebyquery/ShardUpdateByQueryRequest.java
+++ b/src/main/java/org/elasticsearch/action/updatebyquery/ShardUpdateByQueryRequest.java
@@ -19,19 +19,16 @@
 
 package org.elasticsearch.action.updatebyquery;
 
+import static org.elasticsearch.action.ValidateActions.addValidationError;
+
+import java.io.IOException;
+
 import org.elasticsearch.action.ActionRequestValidationException;
 import org.elasticsearch.action.support.replication.ShardReplicationOperationRequest;
 import org.elasticsearch.common.Strings;
 import org.elasticsearch.common.bytes.BytesReference;
 import org.elasticsearch.common.io.stream.StreamInput;
 import org.elasticsearch.common.io.stream.StreamOutput;
-
-import java.io.IOException;
-import java.util.HashMap;
-import java.util.Map;
-
-import static org.elasticsearch.common.collect.Maps.newHashMap;
-import static org.elasticsearch.action.ValidateActions.addValidationError;
 
 /**
  * Represents a shard update by query request, that will be performed on the targeted shard.

--- a/src/main/java/org/elasticsearch/action/updatebyquery/TransportUpdateByQueryAction.java
+++ b/src/main/java/org/elasticsearch/action/updatebyquery/TransportUpdateByQueryAction.java
@@ -19,7 +19,13 @@
 
 package org.elasticsearch.action.updatebyquery;
 
-import org.elasticsearch.common.collect.Lists;
+import java.util.ArrayList;
+import java.util.List;
+import java.util.Map;
+import java.util.Set;
+import java.util.concurrent.atomic.AtomicInteger;
+import java.util.concurrent.atomic.AtomicReferenceArray;
+
 import org.elasticsearch.ExceptionsHelper;
 import org.elasticsearch.action.ActionListener;
 import org.elasticsearch.action.UnavailableShardsException;
@@ -43,13 +49,11 @@ import org.elasticsearch.common.settings.Settings;
 import org.elasticsearch.common.unit.TimeValue;
 import org.elasticsearch.node.NodeClosedException;
 import org.elasticsearch.threadpool.ThreadPool;
-import org.elasticsearch.transport.*;
-
-import java.util.List;
-import java.util.Map;
-import java.util.Set;
-import java.util.concurrent.atomic.AtomicInteger;
-import java.util.concurrent.atomic.AtomicReferenceArray;
+import org.elasticsearch.transport.BaseTransportRequestHandler;
+import org.elasticsearch.transport.BaseTransportResponseHandler;
+import org.elasticsearch.transport.TransportChannel;
+import org.elasticsearch.transport.TransportException;
+import org.elasticsearch.transport.TransportService;
 
 /**
  * Delegates a {@link IndexUpdateByQueryRequest} to the primary shards of the index this request is targeted to.
@@ -131,8 +135,8 @@ public class TransportUpdateByQueryAction extends TransportAction<UpdateByQueryR
         private void finishHim() {
             long tookInMillis = System.currentTimeMillis() - startTime;
             UpdateByQueryResponse response = new UpdateByQueryResponse(tookInMillis);
-            List<IndexUpdateByQueryResponse> indexResponses = Lists.newArrayList();
-            List<String> indexFailures = Lists.newArrayList();
+            List<IndexUpdateByQueryResponse> indexResponses = new ArrayList();
+            List<String> indexFailures = new ArrayList();
             for (int i = 0; i < expectedNumberOfResponses; i++) {
                 IndexUpdateByQueryResponse indexResponse = successFullIndexResponses.get(i);
                 if (indexResponse != null) {
@@ -215,7 +219,7 @@ public class TransportUpdateByQueryAction extends TransportAction<UpdateByQueryR
                 return false;
             }
 
-            List<ShardRouting> primaryShards = Lists.newArrayList();
+            List<ShardRouting> primaryShards = new ArrayList();
             GroupShardsIterator groupShardsIterator =
                     clusterService.operationRouting().deleteByQueryShards(state, request.index(), request.routing());
             for (ShardIterator shardIt : groupShardsIterator) {

--- a/src/main/java/org/elasticsearch/action/updatebyquery/UpdateByQuerySourceBuilder.java
+++ b/src/main/java/org/elasticsearch/action/updatebyquery/UpdateByQuerySourceBuilder.java
@@ -19,6 +19,10 @@
 
 package org.elasticsearch.action.updatebyquery;
 
+import java.io.IOException;
+import java.util.HashMap;
+import java.util.Map;
+
 import org.elasticsearch.common.bytes.BytesReference;
 import org.elasticsearch.common.xcontent.ToXContent;
 import org.elasticsearch.common.xcontent.XContentBuilder;
@@ -26,11 +30,6 @@ import org.elasticsearch.common.xcontent.XContentFactory;
 import org.elasticsearch.common.xcontent.XContentType;
 import org.elasticsearch.index.query.QueryBuilder;
 import org.elasticsearch.search.builder.SearchSourceBuilderException;
-
-import java.io.IOException;
-import java.util.Map;
-
-import static org.elasticsearch.common.collect.Maps.newHashMap;
 
 /**
  * Source builder of the script, lang, params and query for a update by query request.
@@ -41,7 +40,7 @@ public class UpdateByQuerySourceBuilder implements ToXContent {
     private BytesReference queryBinary;
     private String script;
     private String scriptLang;
-    private Map<String, Object> scriptParams = newHashMap();
+    private Map<String, Object> scriptParams = new HashMap();
 
     public UpdateByQuerySourceBuilder query(QueryBuilder query) {
         this.queryBuilder = query;

--- a/src/main/java/org/elasticsearch/rest/action/updatebyquery/RestUpdateByQueryAction.java
+++ b/src/main/java/org/elasticsearch/rest/action/updatebyquery/RestUpdateByQueryAction.java
@@ -19,31 +19,39 @@
 
 package org.elasticsearch.rest.action.updatebyquery;
 
+import static org.elasticsearch.rest.RestRequest.Method.POST;
+import static org.elasticsearch.rest.RestStatus.OK;
+
+import java.io.IOException;
+import java.util.Map;
+
 import org.elasticsearch.action.ActionListener;
 import org.elasticsearch.action.WriteConsistencyLevel;
 import org.elasticsearch.action.bulk.BulkItemResponse;
 import org.elasticsearch.action.support.replication.ReplicationType;
-import org.elasticsearch.action.updatebyquery.*;
+import org.elasticsearch.action.updatebyquery.BulkResponseOption;
+import org.elasticsearch.action.updatebyquery.IndexUpdateByQueryResponse;
+import org.elasticsearch.action.updatebyquery.UpdateByQueryRequest;
+import org.elasticsearch.action.updatebyquery.UpdateByQueryResponse;
+import org.elasticsearch.action.updatebyquery.UpdateByQuerySourceBuilder;
 import org.elasticsearch.client.Client;
 import org.elasticsearch.client.UpdateByQueryClient;
 import org.elasticsearch.client.UpdateByQueryClientWrapper;
+import org.elasticsearch.common.Strings;
 import org.elasticsearch.common.bytes.BytesArray;
 import org.elasticsearch.common.inject.Inject;
 import org.elasticsearch.common.settings.Settings;
 import org.elasticsearch.common.unit.TimeValue;
 import org.elasticsearch.common.xcontent.XContentBuilder;
 import org.elasticsearch.common.xcontent.XContentBuilderString;
-import org.elasticsearch.rest.*;
+import org.elasticsearch.rest.BaseRestHandler;
+import org.elasticsearch.rest.RestChannel;
+import org.elasticsearch.rest.RestController;
+import org.elasticsearch.rest.RestRequest;
+import org.elasticsearch.rest.XContentRestResponse;
+import org.elasticsearch.rest.XContentThrowableRestResponse;
 import org.elasticsearch.rest.action.support.RestActions;
 import org.elasticsearch.rest.action.support.RestXContentBuilder;
-
-import java.io.IOException;
-import java.util.Map;
-
-import static org.elasticsearch.rest.RestRequest.Method.POST;
-import static org.elasticsearch.rest.RestStatus.OK;
-import static org.elasticsearch.rest.action.support.RestActions.splitIndices;
-import static org.elasticsearch.rest.action.support.RestActions.splitTypes;
 
 /**
  * Rest handler for update by query requests.
@@ -62,8 +70,8 @@ public class RestUpdateByQueryAction extends BaseRestHandler {
 
     public void handleRequest(final RestRequest request, final RestChannel channel) {
         UpdateByQueryRequest udqRequest = new UpdateByQueryRequest(
-                splitIndices(request.param("index")),
-                splitTypes(request.param("type"))
+        		Strings.splitStringByCommaToArray(request.param("index")),
+        		Strings.splitStringByCommaToArray(request.param("type"))
         );
         udqRequest.listenerThreaded(false);
         String replicationType = request.param("replication");


### PR DESCRIPTION
Hi,

thanks for this plugin! I need to use it against ES 0.90.4 so I've made 2 changes:
Firstly removed the splitIndices/splitTypes methods as they are removed by this commit:
https://github.com/elasticsearch/elasticsearch/issues/3680

Also, the org.elasticsearch.common.collect.Sets type utilities seem to have been removed, so I've just replaced these with new HashSet etc.

Please let me know if this is ok.
