### PR TITLE
upgraded to ES 1.0.0.Beta2

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -10,7 +10,7 @@
 
     <groupId>com.yakaz.elasticsearch.plugins</groupId>
     <artifactId>elasticsearch-action-updatebyquery</artifactId>
-    <version>1.4.0</version>
+    <version>1.5.0.Beta2</version>
     <packaging>jar</packaging>
 
     <url>http://github.com/yakaz/elasticsearch-action-updatebyquery</url>
@@ -45,7 +45,7 @@
     </parent>
 
     <properties>
-        <elasticsearch.version>0.90.6</elasticsearch.version>
+        <elasticsearch.version>1.0.0.Beta2</elasticsearch.version>
     </properties>
 
     <dependencies>


### PR DESCRIPTION
Hi,

Thanks again for this plugin - I previously put in a pull request for upgrade and here's another one!

this is a pull request for an upgrade to Elasticsearch 1.0.0.Beta2
It's only very minor changes in the pom and src/main/java/org/elasticsearch/action/updatebyquery/TransportShardUpdateByQueryAction.java

However, I am seeing some failures in the integration tests:
org.elasticsearch.test.integration.updatebyquery.UpdateByQueryTests

When waiting for the cluster to be green, it is timing out and getting a yellow status. If I comment out these lines in the tests, they pass:
        assertThat(clusterHealth.isTimedOut(), equalTo(false));
        assertThat(clusterHealth.getStatus(), equalTo(ClusterHealthStatus.GREEN));
 but I'm not sure why this consistently fails.

It's possibly a change to the cluster setup, or possibly something about my environment.
I'm just wondering if these tests pass for you? I will keep looking in the meantime.

thanks
Bob.
